### PR TITLE
バリデーション修正 #17

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,10 +37,10 @@ func GetStores(req request) ([]response, error) {
 
 	// 各言語ごとにぐるなびAPIにリクエストを出す
 	for _, l := range req.Langs {
-		// 対応する言語かどうか判別するバリデーション
-		err := Validation(l)
+		err := Validation(&l)
 		if err != nil {
-			return []response{}, err
+			// 非対応言語は処理スキップ
+			continue
 		}
 
 		res, err := GnaviRequest(l)

--- a/api/validations.go
+++ b/api/validations.go
@@ -2,10 +2,10 @@ package api
 
 import "errors"
 
-func Validation(req string) error {
+func Validation(req *string) error {
 	var langs = []string{"ja", "zh_cn", "zh_tw", "ko", "en"}
 	for _, l := range langs {
-		if req == l {
+		if (*req) == l {
 			return nil
 		}
 	}


### PR DESCRIPTION
# What
現状、複数言語リクエストして一つでも対応する言語がない場合、エラーを返してしまう仕様になってしまっているため、対応する言語が一つでも存在する場合は対応する分レスポンスするように、変更を加える。

# Why
外部APIとの不要なアクセスを防ぐため。